### PR TITLE
removed repeated pip3 install

### DIFF
--- a/doc/source/README.rst
+++ b/doc/source/README.rst
@@ -16,7 +16,7 @@ To create a package and install it do
 ::
 
    make package
-   pip3 install pip3 install build/dist/abcpy-0.1-py3-none-any.whl
+   pip3 install build/dist/abcpy-0.1-py3-none-any.whl
 
 Note that ABCpy requires Python3.
 


### PR DESCRIPTION
This is just something I noticed in the documentation. I think it's a mistake but I could be wrong!