### PR TITLE
fix issue with perturbation kernel for very small values in cov matrix

### DIFF
--- a/abcpy/perturbationkernel.py
+++ b/abcpy/perturbationkernel.py
@@ -1,8 +1,10 @@
 from abc import ABCMeta, abstractmethod
-from abcpy.probabilisticmodels import Continuous
+
 import numpy as np
-from scipy.stats import multivariate_normal
 from scipy.special import gamma
+from scipy.stats import multivariate_normal
+
+from abcpy.probabilisticmodels import Continuous
 
 
 class PerturbationKernel(metaclass = ABCMeta):
@@ -336,7 +338,7 @@ class MultivariateNormalKernel(PerturbationKernel, ContinuousKernel):
 
         cov = np.array(accepted_parameters_manager.accepted_cov_mats_bds.value()[kernel_index]).astype(float)
 
-        return multivariate_normal(mean, cov).pdf(x)
+        return multivariate_normal(mean, cov, allow_singular=True).pdf(x)
 
 
 class MultivariateStudentTKernel(PerturbationKernel, ContinuousKernel):
@@ -569,5 +571,4 @@ class DefaultKernel(JointPerturbationKernel):
             super(DefaultKernel, self).__init__([continuous_kernel])
         else:
             super(DefaultKernel, self).__init__([continuous_kernel, discrete_kernel])
-
 


### PR DESCRIPTION
I had issues with the multivariate perturbation kernel for covariance matrices with very small entries, such that scipy complained that these matrices are singular, although they are badly scaled but not singular at all.

This small fix resolves the issue.

This is a replacement for my other pull request `fix_singular_perturbation_kernel` which hopefully passed travis tests.