### PR TITLE
Improve statistics learning with NN

### DIFF
--- a/abcpy/NN_utilities/algorithms.py
+++ b/abcpy/NN_utilities/algorithms.py
@@ -16,9 +16,10 @@ else:
 
 
 def contrastive_training(samples, similarity_set, embedding_net, cuda, batch_size=16, n_epochs=200,
-                         positive_weight=None, load_all_data_GPU=False, margin=1., lr=None, optimizer=None,
-                         scheduler=None, start_epoch=0, verbose=False, optimizer_kwargs={}, scheduler_kwargs={},
-                         loader_kwargs={}):
+                         samples_val=None, similarity_set_val=None, early_stopping=False, epochs_early_stopping_interval=1,
+                         start_epoch_early_stopping=10, positive_weight=None, load_all_data_GPU=False, margin=1.,
+                         lr=None, optimizer=None, scheduler=None, start_epoch_training=0,
+                         optimizer_kwargs={}, scheduler_kwargs={}, loader_kwargs={}):
     """ Implements the algorithm for the contrastive distance learning training of a neural network; need to be
      provided with a set of samples and the corresponding similarity matrix"""
 
@@ -33,6 +34,14 @@ def contrastive_training(samples, similarity_set, embedding_net, cuda, batch_siz
     similarities_dataset = Similarities(samples, similarity_set, "cuda" if cuda and load_all_data_GPU else "cpu")
     pairs_dataset = SiameseSimilarities(similarities_dataset, positive_weight=positive_weight)
 
+    if (samples_val is None) != (similarity_set_val is None):
+        raise RuntimeError("val samples and similarity set need to be provided together.")
+
+    if samples_val is not None:
+        similarities_dataset_val = Similarities(samples_val, similarity_set_val,
+                                                 "cuda" if cuda and load_all_data_GPU else "cpu")
+        pairs_dataset_val = SiameseSimilarities(similarities_dataset_val, positive_weight=positive_weight)
+
     if cuda:
         if load_all_data_GPU:
             loader_kwargs_2 = {'num_workers': 0, 'pin_memory': False}
@@ -45,6 +54,11 @@ def contrastive_training(samples, similarity_set, embedding_net, cuda, batch_siz
 
     pairs_train_loader = torch.utils.data.DataLoader(pairs_dataset, batch_size=batch_size, shuffle=True,
                                                      **loader_kwargs)
+    if samples_val is not None:
+        pairs_train_loader_val = torch.utils.data.DataLoader(pairs_dataset_val, batch_size=batch_size, shuffle=False,
+                                                              **loader_kwargs)
+    else:
+        pairs_train_loader_val = None
 
     model_contrastive = SiameseNet(embedding_net)
 
@@ -66,14 +80,20 @@ def contrastive_training(samples, similarity_set, embedding_net, cuda, batch_siz
         scheduler = scheduler(optimizer, **scheduler_kwargs)
 
     # now train:
-    fit(pairs_train_loader, model_contrastive, loss_fn, optimizer, scheduler, n_epochs, cuda, start_epoch=start_epoch)
+    fit(pairs_train_loader, model_contrastive, loss_fn, optimizer, scheduler, n_epochs, cuda,
+        val_loader=pairs_train_loader_val,
+        early_stopping=early_stopping, start_epoch_early_stopping=start_epoch_early_stopping,
+        epochs_early_stopping_interval=epochs_early_stopping_interval, start_epoch_training=start_epoch_training)
 
     return embedding_net
 
 
 def triplet_training(samples, similarity_set, embedding_net, cuda, batch_size=16, n_epochs=400,
-                     load_all_data_GPU=False, margin=1., lr=None, optimizer=None, scheduler=None, start_epoch=0,
-                     verbose=False, optimizer_kwargs={}, scheduler_kwargs={}, loader_kwargs={}):
+                     samples_val=None, similarity_set_val=None, early_stopping=False, epochs_early_stopping_interval=1,
+                     start_epoch_early_stopping=10,
+                     load_all_data_GPU=False, margin=1., lr=None, optimizer=None, scheduler=None,
+                     start_epoch_training=0,
+                     optimizer_kwargs={}, scheduler_kwargs={}, loader_kwargs={}):
     """ Implements the algorithm for the triplet distance learning training of a neural network; need to be
      provided with a set of samples and the corresponding similarity matrix"""
 
@@ -87,6 +107,14 @@ def triplet_training(samples, similarity_set, embedding_net, cuda, batch_size=16
     similarities_dataset = Similarities(samples, similarity_set, "cuda" if cuda and load_all_data_GPU else "cpu")
     triplets_dataset = TripletSimilarities(similarities_dataset)
 
+    if (samples_val is None) != (similarity_set_val is None):
+        raise RuntimeError("val samples and similarity set need to be provided together.")
+
+    if samples_val is not None:
+        similarities_dataset_val = Similarities(samples_val, similarity_set_val,
+                                                 "cuda" if cuda and load_all_data_GPU else "cpu")
+        triplets_dataset_val = TripletSimilarities(similarities_dataset_val)
+
     if cuda:
         if load_all_data_GPU:
             loader_kwargs_2 = {'num_workers': 0, 'pin_memory': False}
@@ -99,6 +127,11 @@ def triplet_training(samples, similarity_set, embedding_net, cuda, batch_size=16
 
     triplets_train_loader = torch.utils.data.DataLoader(triplets_dataset, batch_size=batch_size, shuffle=True,
                                                         **loader_kwargs)
+    if samples_val is not None:
+        triplets_train_loader_val = torch.utils.data.DataLoader(triplets_dataset_val, batch_size=batch_size,
+                                                                 shuffle=False, **loader_kwargs)
+    else:
+        triplets_train_loader_val = None
 
     model_triplet = TripletNet(embedding_net)
 
@@ -120,13 +153,17 @@ def triplet_training(samples, similarity_set, embedding_net, cuda, batch_size=16
         scheduler = scheduler(optimizer, **scheduler_kwargs)
 
     # now train:
-    fit(triplets_train_loader, model_triplet, loss_fn, optimizer, scheduler, n_epochs, cuda, start_epoch=start_epoch)
+    fit(triplets_train_loader, model_triplet, loss_fn, optimizer, scheduler, n_epochs, cuda,
+        val_loader=triplets_train_loader_val,
+        early_stopping=early_stopping, start_epoch_early_stopping=start_epoch_early_stopping,
+        epochs_early_stopping_interval=epochs_early_stopping_interval, start_epoch_training=start_epoch_training)
 
     return embedding_net
 
 
-def FP_nn_training(samples, target, embedding_net, cuda, batch_size=1, n_epochs=50, load_all_data_GPU=False,
-                   lr=1e-3, optimizer=None, scheduler=None, start_epoch=0, verbose=False, optimizer_kwargs={},
+def FP_nn_training(samples, target, embedding_net, cuda, batch_size=1, n_epochs=50, samples_val=None, target_val=None,
+                   early_stopping=False, epochs_early_stopping_interval=1, start_epoch_early_stopping=10, load_all_data_GPU=False,
+                   lr=1e-3, optimizer=None, scheduler=None, start_epoch_training=0, optimizer_kwargs={},
                    scheduler_kwargs={}, loader_kwargs={}):
     """ Implements the algorithm for the training of a neural network based on regressing the values of the parameters
     on the corresponding simulation outcomes; it is effectively a training with a mean squared error loss. Needs to be
@@ -142,6 +179,13 @@ def FP_nn_training(samples, target, embedding_net, cuda, batch_size=1, n_epochs=
 
     dataset_FP_nn = ParameterSimulationPairs(samples, target, "cuda" if cuda and load_all_data_GPU else "cpu")
 
+    if (samples_val is None) != (target_val is None):
+        raise RuntimeError("val samples and similarity set need to be provided together.")
+
+    if samples_val is not None:
+        dataset_FP_nn_val = ParameterSimulationPairs(samples_val, target_val,
+                                                      "cuda" if cuda and load_all_data_GPU else "cpu")
+
     if cuda:
         if load_all_data_GPU:
             loader_kwargs_2 = {'num_workers': 0, 'pin_memory': False}
@@ -153,6 +197,12 @@ def FP_nn_training(samples, target, embedding_net, cuda, batch_size=1, n_epochs=
     loader_kwargs.update(loader_kwargs_2)
 
     data_loader_FP_nn = torch.utils.data.DataLoader(dataset_FP_nn, batch_size=batch_size, shuffle=True, **loader_kwargs)
+
+    if samples_val is not None:
+        data_loader_FP_nn_val = torch.utils.data.DataLoader(dataset_FP_nn_val, batch_size=batch_size,
+                                                             shuffle=False, **loader_kwargs)
+    else:
+        data_loader_FP_nn_val = None
 
     if cuda:
         embedding_net.cuda()
@@ -169,6 +219,9 @@ def FP_nn_training(samples, target, embedding_net, cuda, batch_size=1, n_epochs=
         scheduler = scheduler(optimizer, **scheduler_kwargs)
 
     # now train:
-    fit(data_loader_FP_nn, embedding_net, loss_fn, optimizer, scheduler, n_epochs, cuda, start_epoch=start_epoch)
+    fit(data_loader_FP_nn, embedding_net, loss_fn, optimizer, scheduler, n_epochs, cuda,
+        val_loader=data_loader_FP_nn_val,
+        early_stopping=early_stopping, start_epoch_early_stopping=start_epoch_early_stopping,
+        epochs_early_stopping_interval=epochs_early_stopping_interval, start_epoch_training=start_epoch_training)
 
     return embedding_net

--- a/abcpy/NN_utilities/datasets.py
+++ b/abcpy/NN_utilities/datasets.py
@@ -37,7 +37,7 @@ class Similarities(Dataset):
 
 class SiameseSimilarities(Dataset):
     """
-    This class defines a dataset returning pairs of similar and dissimilar examples. It has to be instantiated with a
+    This class defines a dataset returning pairs of similar and dissimilar samples. It has to be instantiated with a
     dataset of the class Similarities
     """
 
@@ -88,7 +88,7 @@ class SiameseSimilarities(Dataset):
 
 class TripletSimilarities(Dataset):
     """
-    This class defines a dataset returning triplets of anchor, positive and negative examples. 
+    This class defines a dataset returning triplets of anchor, positive and negative samples.
     It has to be instantiated with a dataset of the class Similarities.
     """
 

--- a/abcpy/NN_utilities/networks.py
+++ b/abcpy/NN_utilities/networks.py
@@ -1,3 +1,4 @@
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
@@ -97,3 +98,16 @@ def createDefaultNN(input_size, output_size, hidden_sizes=None, nonlinearity=Non
 
     return DefaultNN
 
+
+class ScalerAndNet(nn.Module):
+    """Defines a nn.Module class that wraps a scaler and a neural network, and applies the scaler before passing the
+    data through the neural network."""
+
+    def __init__(self, net, scaler):
+        super().__init__()
+        self.net = net
+        self.scaler = scaler
+
+    def forward(self, x):
+        x = torch.tensor(self.scaler.transform(x), dtype=torch.float32).to(next(self.net.parameters()).device)
+        return self.net(x)

--- a/abcpy/NN_utilities/trainer.py
+++ b/abcpy/NN_utilities/trainer.py
@@ -43,14 +43,17 @@ def fit(train_loader, model, loss_fn, optimizer, scheduler, n_epochs, cuda, val_
             # early stopping:
             if early_stopping and (epoch + 1) % epochs_early_stopping_interval == 0:
                 validation_loss_list.append(val_loss)  # save the previous validation loss. It is actually
-                net_state_dict = model.state_dict()
-                # we need to have at least two saved test losses for performing early stopping.
+                # we need to have at least two saved test losses for performing early stopping (in which case we know
+                # we have saved the previous state_dict as well).
                 if epoch + 1 >= start_epoch_early_stopping and len(validation_loss_list) > 1:
                     if validation_loss_list[-1] > validation_loss_list[-2]:
                         logger.info("Training has been early stopped at epoch {}.".format(epoch + 1))
                         # reload the previous state dict:
                         model.load_state_dict(net_state_dict)
                         break  # stop training
+                # if we did not stop: update the state dict to the next value
+                net_state_dict = model.state_dict()
+
         scheduler.step()
 
 

--- a/abcpy/NN_utilities/trainer.py
+++ b/abcpy/NN_utilities/trainer.py
@@ -12,9 +12,6 @@ def fit(train_loader, model, loss_fn, optimizer, scheduler, n_epochs, cuda, val_
     i.e. The model should be able to process data output of loaders,
     loss function should process target output of loaders and outputs from the model
 
-    Examples: Classification: batch loader, classification model, NLL loss, accuracy metric
-    Siamese network: Siamese loader, siamese model, contrastive loss
-
     Adapted from https://github.com/adambielski/siamese-triplet
     """
 

--- a/abcpy/NN_utilities/trainer.py
+++ b/abcpy/NN_utilities/trainer.py
@@ -1,8 +1,10 @@
 from tqdm import tqdm
 import logging
+import torch
 
 
-def fit(train_loader, model, loss_fn, optimizer, scheduler, n_epochs, cuda, start_epoch=0):
+def fit(train_loader, model, loss_fn, optimizer, scheduler, n_epochs, cuda, val_loader=None, early_stopping=False,
+        epochs_early_stopping_interval=1, start_epoch_early_stopping=10, start_epoch_training=0):
     """
     Basic function to train a neural network given a train_loader, a loss function and an optimizer.
 
@@ -17,17 +19,39 @@ def fit(train_loader, model, loss_fn, optimizer, scheduler, n_epochs, cuda, star
     """
 
     logger = logging.getLogger("NN Trainer")
+    if early_stopping and val_loader is not None:
+        validation_loss_list = []
+    if early_stopping and val_loader is None:
+        raise RuntimeError("You cannot perform early stopping if a validation loader is not provided to the training "
+                           "routine")
 
-    for epoch in range(0, start_epoch):
+    for epoch in range(0, start_epoch_training):
         scheduler.step()
 
-    for epoch in tqdm(range(start_epoch, n_epochs)):
-        scheduler.step()
-
+    for epoch in tqdm(range(start_epoch_training, n_epochs)):
         # Train stage
         train_loss = train_epoch(train_loader, model, loss_fn, optimizer, cuda)
 
         logger.debug('Epoch: {}/{}. Train set: Average loss: {:.4f}'.format(epoch + 1, n_epochs, train_loss))
+
+        # Validation stage
+        if val_loader is not None:
+            val_loss = test_epoch(val_loader, model, loss_fn, cuda)
+
+            logger.debug('Epoch: {}/{}. Validation set: Average loss: {:.4f}'.format(epoch + 1, n_epochs, val_loss))
+
+            # early stopping:
+            if early_stopping and (epoch + 1) % epochs_early_stopping_interval == 0:
+                validation_loss_list.append(val_loss)  # save the previous validation loss. It is actually
+                net_state_dict = model.state_dict()
+                # we need to have at least two saved test losses for performing early stopping.
+                if epoch + 1 >= start_epoch_early_stopping and len(validation_loss_list) > 1:
+                    if validation_loss_list[-1] > validation_loss_list[-2]:
+                        logger.info("Training has been early stopped at epoch {}.".format(epoch + 1))
+                        # reload the previous state dict:
+                        model.load_state_dict(net_state_dict)
+                        break  # stop training
+        scheduler.step()
 
 
 def train_epoch(train_loader, model, loss_fn, optimizer, cuda):
@@ -36,7 +60,6 @@ def train_epoch(train_loader, model, loss_fn, optimizer, cuda):
     Adapted from https://github.com/adambielski/siamese-triplet
     """
     model.train()
-    losses = []
     total_loss = 0
 
     for batch_idx, (data, target) in enumerate(train_loader):
@@ -61,12 +84,41 @@ def train_epoch(train_loader, model, loss_fn, optimizer, cuda):
 
         loss_outputs = loss_fn(*loss_inputs)
         loss = loss_outputs[0] if type(loss_outputs) in (tuple, list) else loss_outputs
-        losses.append(loss.item())
         total_loss += loss.item()
         loss.backward()
         optimizer.step()
 
-        losses = []
+    return total_loss / (batch_idx + 1)  # divide here by the number of elements in the batch.
 
-    total_loss /= (batch_idx + 1)
-    return total_loss
+
+def test_epoch(val_loader, model, loss_fn, cuda):
+    """Function implementing the computation of the validation error, in batches.
+
+    Adapted from https://github.com/adambielski/siamese-triplet
+    """
+    with torch.no_grad():
+        model.eval()
+        val_loss = 0
+        for batch_idx, (data, target) in enumerate(val_loader):
+            target = target if len(target) > 0 else None
+            if not type(data) in (tuple, list):
+                data = (data,)
+            if cuda:
+                data = tuple(d.cuda() for d in data)
+                if target is not None:
+                    target = target.cuda()
+
+            outputs = model(*data)
+
+            if type(outputs) not in (tuple, list):
+                outputs = (outputs,)
+            loss_inputs = outputs
+            if target is not None:
+                target = (target,)
+                loss_inputs += target
+
+            loss_outputs = loss_fn(*loss_inputs)
+            loss = loss_outputs[0] if type(loss_outputs) in (tuple, list) else loss_outputs
+            val_loss += loss.item()
+
+    return val_loss / (batch_idx + 1)  # divide here by the number of elements in the batch.

--- a/abcpy/distances.py
+++ b/abcpy/distances.py
@@ -136,7 +136,7 @@ class Euclidean(Distance):
         # Check whether d1 is same as self.data_set
         if self.data_set is not None:
             if len(np.array(d1[0]).reshape(-1,)) == 1:
-                self.data_set == d1
+                self.dataSame = self.data_set == d1
             else:
                 self.dataSame = all([(np.array(self.data_set[i]) == np.array(d1[i])).all() for i in range(len(d1))])
 

--- a/abcpy/graphtools.py
+++ b/abcpy/graphtools.py
@@ -96,7 +96,7 @@ class GraphTools():
             Defines the models for which the pdf of their prior should be evaluated
         parameters: python list
             The parameters at which the pdf should be evaluated
-        mapping: list of tupels
+        mapping: list of tuples
             Defines the mapping of probabilistic models and index in a parameter list.
         is_root: boolean
             A flag specifying whether the provided models are the root models. This is to ensure that the pdf is calculated correctly.
@@ -121,7 +121,7 @@ class GraphTools():
             Defines the models for which the pdf of their prior should be evaluated
         parameters: python list
             The parameters at which the pdf should be evaluated
-        mapping: list of tupels
+        mapping: list of tuples
             Defines the mapping of probabilistic models and index in a parameter list.
         is_root: boolean
             A flag specifying whether the provided models are the root models. This is to ensure that the pdf is calculated correctly.
@@ -234,7 +234,7 @@ class GraphTools():
         Returns
         -------
         list:
-            Each entry is a tupel, the first entry of which is the name of the model and the second entry is the parameter values associated with it
+            Each entry is a tuple, the first entry of which is the name of the model and the second entry is the parameter values associated with it
         """
         mapping = self._get_mapping()[0]
 

--- a/abcpy/output.py
+++ b/abcpy/output.py
@@ -80,12 +80,14 @@ class Journal:
 
     def add_user_parameters(self, names_and_params):
         """
-        Saves the provided parameters and names of the probabilistic models corresponding to them. If type==0, old parameters get overwritten.
+        Saves the provided parameters and names of the probabilistic models corresponding to them. If type==0, old
+        parameters get overwritten.
 
         Parameters
         ----------
         names_and_params: list
-            Each entry is a tupel, where the first entry is the name of the probabilistic model, and the second entry is the parameters associated with this model.
+            Each entry is a tuple, where the first entry is the name of the probabilistic model, and the second entry is
+            the parameters associated with this model.
         """
         if (self._type == 0):
             self.names_and_parameters = [dict(names_and_params)]
@@ -141,7 +143,8 @@ class Journal:
 
     def add_opt_values(self, opt_values):
         """
-        Saves provided values of the evaluation of the schemes objective function. If type==0, old values get overwritten
+        Saves provided values of the evaluation of the schemes objective function. If type==0, old values get
+        overwritten
 
         Parameters
         ----------
@@ -267,8 +270,8 @@ class Journal:
         Returns
         -------
         posterior mean: dictionary
-            Posterior mean from the specified iteration (last, if not specified) returned as a disctionary with names of the
-            random variables
+            Posterior mean from the specified iteration (last, if not specified) returned as a disctionary with names of
+            the random variables
         """
 
         if iteration is None:
@@ -352,13 +355,16 @@ class Journal:
         pair of parameters.
 
         This visualization is not satisfactory for parameters that take on discrete values, specially in the case where
-        the number of values it can assume are small.
+        the number of values it can assume are small, as it obtains the posterior by KDE in this case as well. We need
+        to improve on that, considering histograms.
 
         Parameters
         ----------
         parameters_to_show : list, optional
             a list of the parameters for which you want to plot the posterior distribution. For each parameter, you need
-            to provide the name string as it was defined in the model.
+            to provide the name string as it was defined in the model. For instance,
+            `jrnl.plot_posterior_distr(parameters_to_show=["mu"])` will only plot the posterior distribution for the
+            parameter named "mu" in the list of parameters.
             If `None`, then all parameters will be displayed.
         ranges_parameters : Python dictionary, optional
             a dictionary in which you can optionally provide the plotting range for the parameters that you chose to
@@ -373,8 +379,8 @@ class Journal:
             specifies if you want to show the posterior samples overimposed to the contourplots of the posterior
             distribution. If `None`, the default behaviour is the following: if the posterior samples are associated
             with importance weights, then the samples are not showed (in fact, the KDE for the posterior distribution
-            takes into account the weights, and showing the samples may be misleading). Otherwise, if the posterior #
-            samples are not associated with weights, they are displayed by defauly.
+            takes into account the weights, and showing the samples may be misleading). Otherwise, if the posterior
+            samples are not associated with weights, they are displayed by default.
         single_marginals_only : boolean, optional
             if `True`, the method does not show the paired marginals but only the single parameter marginals;
             otherwise, it shows the paired marginals as well. Default to `False`.

--- a/abcpy/perturbationkernel.py
+++ b/abcpy/perturbationkernel.py
@@ -184,7 +184,7 @@ class JointPerturbationKernel(PerturbationKernel):
         Returns
         -------
         list
-            The list contains tupels. Each tupel contains as the first entry a probabilistic model and as the second
+            The list contains tuples. Each tuple contains as the first entry a probabilistic model and as the second
             entry the perturbed parameter values corresponding to this model.
         """
 
@@ -216,7 +216,7 @@ class JointPerturbationKernel(PerturbationKernel):
         Parameters
         ----------
         mapping: list
-            Each entry is a tupel of which the first entry is a abcpy.ProbabilisticModel object, the second entry is the
+            Each entry is a tuple of which the first entry is a abcpy.ProbabilisticModel object, the second entry is the
             index in the accepted_parameters_bds list corresponding to an output of this model.
         accepted_parameters_manager: abcpy.AcceptedParametersManager object
             The AcceptedParametersManager to be used.

--- a/abcpy/probabilisticmodels.py
+++ b/abcpy/probabilisticmodels.py
@@ -292,7 +292,7 @@ class ProbabilisticModel(metaclass = ABCMeta):
 
     def __getitem__(self, item):
         """
-        Overloads the access operator. If the access operator is called, a tupel of the ProbablisticModel that called
+        Overloads the access operator. If the access operator is called, a tuple of the ProbablisticModel that called
         the operator and the index at which it was called is returned. Commonly used at initialization of new
         probabilistic models to specify a mapping between model outputs and parameters.
 

--- a/abcpy/statistics.py
+++ b/abcpy/statistics.py
@@ -1,4 +1,6 @@
 from abc import ABCMeta, abstractmethod
+
+import cloudpickle
 import numpy as np
 
 try:
@@ -7,8 +9,8 @@ except ImportError:
     has_torch = False
 else:
     has_torch = True
-    from abcpy.NN_utilities.utilities import load_net
-    from abcpy.NN_utilities.networks import createDefaultNN
+    from abcpy.NN_utilities.utilities import load_net, save_net
+    from abcpy.NN_utilities.networks import createDefaultNN, ScalerAndNet
 
 
 class Statistics(metaclass=ABCMeta):
@@ -264,8 +266,8 @@ class NeuralEmbedding(Statistics):
         self.previous_statistics = previous_statistics
 
     @classmethod
-    def fromFile(cls, path_to_net_state_dict, network_class=None, input_size=None, output_size=None, hidden_sizes=None,
-                 previous_statistics=None):
+    def fromFile(cls, path_to_net_state_dict, network_class=None, path_to_scaler=None, input_size=None,
+                 output_size=None, hidden_sizes=None, previous_statistics=None):
         """If the neural network state_dict was saved to the disk, this method can be used to instantiate a
         NeuralEmbedding object with that neural network.
 
@@ -280,6 +282,10 @@ class NeuralEmbedding(Statistics):
         In both cases, note that the input size of the neural network must coincide with the size of each of the
         datapoints generated from the model (unless some other statistics are computed beforehand).
 
+        Note that if the neural network was of the class `ScalerAndNet`, ie a scaler was applied before the data is fed
+        through it, you need to pass `path_to_scaler` as well. Then this method will instantiate the network in the
+        correct way.
+
         Parameters
         ----------
         path_to_net_state_dict : basestring
@@ -287,6 +293,10 @@ class NeuralEmbedding(Statistics):
         network_class : torch.nn class, optional
             if the neural network class is known explicitly (for instance if the used defined it), then it has to be
              passed here. This must not be provided together with `input_size` or `output_size`.
+        path_to_scaler: basestring, optional
+            The path where the scaler which was applied before the neural network is saved. Note that if the neural
+            network was trained on scaled data and now you do not pass the correct scaler, the behavior will not be
+            correct, leading to wrong inference. Default to None.
         input_size : integer, optional
             if the neural network is an instance of abcpy.NN_utilities.networks.DefaultNN with some input and
             output size, then you should provide here the input size of the network. It has to be provided together with
@@ -327,13 +337,41 @@ class NeuralEmbedding(Statistics):
 
         if network_class is not None:  # user explicitly passed the NN class
             net = load_net(path_to_net_state_dict, network_class)
-            statistic_object = cls(net, previous_statistics=previous_statistics)
         else:  # the user passed the input_size, output_size and (maybe) the hidden_sizes
             net = load_net(path_to_net_state_dict, createDefaultNN(input_size=input_size, output_size=output_size,
                                                                    hidden_sizes=hidden_sizes))
-            statistic_object = cls(net, previous_statistics=previous_statistics)
+
+        if path_to_scaler is not None:
+            scaler = cloudpickle.load(open(path_to_scaler, 'rb'))
+            net = ScalerAndNet(net, scaler)
+
+        statistic_object = cls(net, previous_statistics=previous_statistics)
 
         return statistic_object
+
+    def save_net(self, path_to_net_state_dict, path_to_scaler=None):
+        """Method to save the neural network state dict to a file. If the network is of the class ScalerAndNet, ie a
+        scaler is applied before the data is fed through the network, then you are required to pass the path where you
+        want the scaler to be saved.
+        Parameters
+        ----------
+        path_to_net_state_dict: basestring
+            Path where the state dict of the neural network is saved.
+        path_to_scaler: basestring
+            Path where the scaler is saved (with pickle); this is required if the neural network is of the class
+            ScalerAndNet, and is ignored otherwise.
+        """
+        # if the net is of the class ScalerAndNet
+        if hasattr(self.net, "scaler") and path_to_scaler is None:
+            raise RuntimeError("You did not specify path_to_scaler, which is required as the neural network is an "
+                               "element of the class `ScalerAndNet`, ie a scaler is applied before the data is fed"
+                               " through the network")
+
+        if hasattr(self.net, "scaler"):
+            save_net(path_to_net_state_dict, self.net.net)
+            cloudpickle.dump(self.net.scaler, open(path_to_scaler, 'wb'))
+        else:
+            save_net(path_to_net_state_dict, self.net)
 
     def statistics(self, data):
         """

--- a/abcpy/statisticslearning.py
+++ b/abcpy/statisticslearning.py
@@ -277,7 +277,6 @@ class Semiautomatic(StatisticsLearning, GraphTools):
         return LinearTransformation(np.transpose(self.coefficients_learnt), previous_statistics=self.statistics_calc)
 
 
-# TODO add scaler before applying the neural network ?
 class StatisticsLearningNN(StatisticsLearning, GraphTools):
     """This is the base class for all the statistics learning techniques involving neural networks. In most cases, you
     should not instantiate this directly. The actual classes instantiate this with the right arguments.

--- a/abcpy/statisticslearning.py
+++ b/abcpy/statisticslearning.py
@@ -292,13 +292,13 @@ class StatisticsLearningNN(StatisticsLearning, GraphTools):
 
         if cuda is None:
             cuda = torch.cuda.is_available()
-        elif cuda and not torch.cuda.is_available:
+        elif cuda and not torch.cuda.is_available():
             # if the user requested to use GPU but no GPU is there
             cuda = False
             self.logger.warning(
                 "You requested to use GPU but no GPU is available! The computation will proceed on CPU.")
 
-        self.device = "cuda" if cuda and torch.cuda.is_available else "cpu"
+        self.device = "cuda" if cuda and torch.cuda.is_available() else "cpu"
         if self.device == "cuda":
             self.logger.debug("We are using GPU to train the network.")
         else:

--- a/abcpy/statisticslearning.py
+++ b/abcpy/statisticslearning.py
@@ -1,6 +1,7 @@
 import logging
 from abc import ABCMeta, abstractmethod
 
+import numpy as np
 from sklearn import linear_model
 
 from abcpy.acceptedparametersmanager import *
@@ -28,8 +29,8 @@ class StatisticsLearning(metaclass=ABCMeta):
     """This abstract base class defines a way to choose the summary statistics.
     """
 
-    def __init__(self, model, statistics_calc, backend, n_samples=1000, n_samples_per_param=1, parameters=None,
-                 simulations=None, seed=None):
+    def __init__(self, model, statistics_calc, backend, n_samples=1000, n_samples_val=0, n_samples_per_param=1,
+                 parameters=None, simulations=None, parameters_val=None, simulations_val=None, seed=None):
 
         """The constructor of a sub-class must accept a non-optional model, statistics calculator and
         backend which are stored to self.model, self.statistics_calc and self.backend. Further it
@@ -53,22 +54,39 @@ class StatisticsLearning(metaclass=ABCMeta):
             The number of (parameter, simulated data) tuple to be generated to learn the summary statistics in pilot
             step. The default value is 1000.
             This is ignored if `simulations` and `parameters` are provided.
+        n_samples_val: int, optional
+            The number of (parameter, simulated data) tuple to be generated to be used as a validation set in the pilot
+            step. The default value is 0, which means no validation set is used.
+            This is ignored if `simulations_val` and `parameters_val` are provided.
         n_samples_per_param: int, optional
             Number of data points in each simulated data set. This is ignored if `simulations` and `parameters` are
             provided. Default to 1.
         parameters: array, optional
             A numpy array with shape (n_samples, n_parameters) that is used, together with `simulations` to fit the
             summary selection learning algorithm. It has to be provided together with `simulations`, in which case no
-            other simulations are performed. Default value is None.
+            other simulations are performed to generate the training data. Default value is None.
         simulations: array, optional
             A numpy array with shape (n_samples, output_size) that is used, together with `parameters` to fit the
             summary selection learning algorithm. It has to be provided together with `parameters`, in which case no
-            other simulations are performed. Default value is None.
+            other simulations are performed to generate the training data. Default value is None.
+        parameters_val: array, optional
+            A numpy array with shape (n_samples_val, n_parameters) that is used, together with `simulations_val` as a 
+            validation set in the summary selection learning algorithm. It has to be provided together with 
+            `simulations_val`, in which case no other simulations are performed to generate the validation set. Default 
+            value is None.
+        simulations_val: array, optional
+            A numpy array with shape (n_samples_val, output_size) that is used, together with `parameters_val` as a 
+            validation set in the summary selection learning algorithm. It has to be provided together with 
+            `parameters_val`, in which case no other simulations are performed to generate the validation set. Default
+            value is None.
         seed: integer, optional
             Optional initial seed for the random number generator. The default value is generated randomly.
         """
         if (parameters is None) != (simulations is None):
             raise RuntimeError("parameters and simulations need to be provided together.")
+
+        if (parameters_val is None) != (simulations_val is None):
+            raise RuntimeError("parameters_val and simulations_val need to be provided together.")
 
         self.model = model
         self.statistics_calc = statistics_calc
@@ -77,7 +95,9 @@ class StatisticsLearning(metaclass=ABCMeta):
         self.n_samples_per_param = n_samples_per_param
         self.logger = logging.getLogger(__name__)
 
-        if parameters is None:  # then also simulations is None
+        n_samples_to_generate = n_samples * (parameters is None) + n_samples_val * (parameters_val is None)
+
+        if n_samples_to_generate > 0:  # need to generate some data 
             self.logger.info('Generation of data...')
 
             self.logger.debug("Definitions for parallelization.")
@@ -87,7 +107,8 @@ class StatisticsLearning(metaclass=ABCMeta):
 
             self.logger.debug("Map phase.")
             # main algorithm
-            seed_arr = self.rng.randint(1, n_samples * n_samples, size=n_samples, dtype=np.int32)
+            seed_arr = self.rng.randint(1, n_samples_to_generate * n_samples_to_generate, size=n_samples_to_generate,
+                                        dtype=np.int32)
             rng_arr = np.array([np.random.RandomState(seed) for seed in seed_arr])
             rng_pds = self.backend.parallelize(rng_arr)
 
@@ -101,24 +122,38 @@ class StatisticsLearning(metaclass=ABCMeta):
 
             self.logger.debug("Reshape data")
             # reshape the sample parameters; so that we can also work with multidimensional parameters
-            self.sample_parameters = sample_parameters.reshape((n_samples, -1))
+            self.sample_parameters = sample_parameters.reshape((n_samples_to_generate, -1))
 
             # now reshape the statistics in the case in which several n_samples_per_param > 1, and repeat the array with
             # the parameters so that the regression algorithms can work on the pair of arrays. Maybe there are smarter
             # ways of doing this.
 
-            self.sample_statistics = self.sample_statistics.reshape(n_samples * self.n_samples_per_param, -1)
-            self.sample_parameters = np.repeat(self.sample_parameters, self.n_samples_per_param, axis=0)
+            sample_statistics_generated = self.sample_statistics.reshape(
+                n_samples_to_generate * self.n_samples_per_param, -1)
+            sample_parameters_generated = np.repeat(self.sample_parameters, self.n_samples_per_param, axis=0)
+            # now split between train and validation set:
+            self.sample_statistics = sample_statistics_generated[
+                                     0: n_samples * self.n_samples_per_param * (parameters is None)]
+            self.sample_parameters = sample_parameters_generated[
+                                     0: n_samples * self.n_samples_per_param * (parameters is None)]
+
+            self.sample_statistics_val = sample_statistics_generated[
+                                         n_samples * self.n_samples_per_param * (parameters is None):len(
+                                             sample_statistics_generated)]
+            self.sample_parameters_val = sample_parameters_generated[
+                                         n_samples * self.n_samples_per_param * (parameters is None):len(
+                                             sample_parameters_generated)]
+
             self.logger.info('Data generation finished.')
 
-        else:
+        if parameters is not None:
             # do all the checks on dimensions:
             if not isinstance(parameters, np.ndarray) or not isinstance(simulations, np.ndarray):
                 raise TypeError("parameters and simulations need to be numpy arrays.")
             if len(parameters.shape) != 2:
                 raise RuntimeError("parameters have to be a 2-dimensional array")
             if len(simulations.shape) != 2:
-                raise RuntimeError("parameters have to be a 2-dimensional array")
+                raise RuntimeError("simulations have to be a 2-dimensional array")
             if simulations.shape[0] != parameters.shape[0]:
                 raise RuntimeError("parameters and simulations need to have the same first dimension")
 
@@ -128,6 +163,24 @@ class StatisticsLearning(metaclass=ABCMeta):
             self.sample_parameters = parameters
 
             self.logger.info("The statistics will be learned using the provided data and parameters")
+
+        if parameters_val is not None:
+            # do all the checks on dimensions:
+            if not isinstance(parameters_val, np.ndarray) or not isinstance(simulations_val, np.ndarray):
+                raise TypeError("parameters_val and simulations_val need to be numpy arrays.")
+            if len(parameters_val.shape) != 2:
+                raise RuntimeError("parameters_val have to be a 2-dimensional array")
+            if len(simulations_val.shape) != 2:
+                raise RuntimeError("simulations_val have to be a 2-dimensional array")
+            if simulations_val.shape[0] != parameters_val.shape[0]:
+                raise RuntimeError("parameters_val and simulations_val need to have the same first dimension")
+
+            # if all checks are passed:
+            self.sample_statistics_val = self.statistics_calc.statistics(
+                [simulations_val[i] for i in range(simulations_val.shape[0])])
+            self.sample_parameters_val = parameters_val
+
+            self.logger.info("The provided validation data and parameters will be used as a validation set.")
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -222,6 +275,7 @@ class Semiautomatic(StatisticsLearning, GraphTools):
         return LinearTransformation(np.transpose(self.coefficients_learnt), previous_statistics=self.statistics_calc)
 
 
+# TODO add scaler before applying the neural network ?
 class StatisticsLearningNN(StatisticsLearning, GraphTools):
     """This is the base class for all the statistics learning techniques involving neural networks. In most cases, you
     should not instantiate this directly. The actual classes instantiate this with the right arguments.
@@ -230,8 +284,9 @@ class StatisticsLearningNN(StatisticsLearning, GraphTools):
     """
 
     def __init__(self, model, statistics_calc, backend, training_routine, distance_learning, embedding_net=None,
-                 n_samples=1000, n_samples_per_param=1, parameters=None, simulations=None, seed=None, cuda=None,
-                 quantile=0.1, **training_routine_kwargs):
+                 n_samples=1000, n_samples_val=0, n_samples_per_param=1, parameters=None, simulations=None,
+                 parameters_val=None, simulations_val=None, seed=None, cuda=None, quantile=0.1,
+                 **training_routine_kwargs):
         """
         Parameters
         ----------
@@ -258,17 +313,31 @@ class StatisticsLearningNN(StatisticsLearning, GraphTools):
             The number of (parameter, simulated data) tuple to be generated to learn the summary statistics in pilot
             step. The default value is 1000.
             This is ignored if `simulations` and `parameters` are provided.
+        n_samples_val: int, optional
+            The number of (parameter, simulated data) tuple to be generated to be used as a validation set in the pilot
+            step. The default value is 0, which means no validation set is used.
+            This is ignored if `simulations_val` and `parameters_val` are provided.
         n_samples_per_param: int, optional
             Number of data points in each simulated data set. This is ignored if `simulations` and `parameters` are
             provided. Default to 1.
         parameters: array, optional
             A numpy array with shape (n_samples, n_parameters) that is used, together with `simulations` to fit the
             summary selection learning algorithm. It has to be provided together with `simulations`, in which case no
-            other simulations are performed. Default value is None.
+            other simulations are performed to generate the training data. Default value is None.
         simulations: array, optional
             A numpy array with shape (n_samples, output_size) that is used, together with `parameters` to fit the
             summary selection learning algorithm. It has to be provided together with `parameters`, in which case no
-            other simulations are performed. Default value is None.
+            other simulations are performed to generate the training data. Default value is None.
+        parameters_val: array, optional
+            A numpy array with shape (n_samples_val, n_parameters) that is used, together with `simulations_val` as a 
+            validation set in the summary selection learning algorithm. It has to be provided together with 
+            `simulations_val`, in which case no other simulations are performed to generate the validation set. Default 
+            value is None.
+        simulations_val: array, optional
+            A numpy array with shape (n_samples_val, output_size) that is used, together with `parameters_val` as a 
+            validation set in the summary selection learning algorithm. It has to be provided together with 
+            `parameters_val`, in which case no other simulations are performed to generate the validation set. Default
+            value is None.
         seed: integer, optional
             Optional initial seed for the random number generator. The default value is generated randomly.
         cuda: boolean, optional
@@ -306,17 +375,29 @@ class StatisticsLearningNN(StatisticsLearning, GraphTools):
 
         # this handles generation of the data (or its formatting in case the data is provided to the Semiautomatic
         # class)
-        super(StatisticsLearningNN, self).__init__(model, statistics_calc, backend, n_samples, n_samples_per_param,
-                                                   parameters, simulations, seed)
+        super(StatisticsLearningNN, self).__init__(model, statistics_calc, backend, n_samples, n_samples_val,
+                                                   n_samples_per_param, parameters, simulations, seed=seed,
+                                                   parameters_val=parameters_val, simulations_val=simulations_val)
+
+        # we have a validation set if it has the following attribute with size larger than 0
+        has_val_set = hasattr(self, "sample_parameters_val") and len(self.sample_parameters_val) > 0
 
         self.logger.info('Learning of the transformation...')
         # Define Data
-        target, simulations_reshaped = self.sample_parameters, self.sample_statistics
+        target, simulations = self.sample_parameters, self.sample_statistics
+        if has_val_set:
+            target_val, simulations_val = self.sample_parameters_val, self.sample_statistics_val
+        else:
+            target_val, simulations_val = None, None
 
         if distance_learning:
             self.logger.debug("Computing similarity matrix...")
             # define the similarity set
             similarity_set = compute_similarity_matrix(target, quantile)
+            if has_val_set:
+                similarity_set_val = compute_similarity_matrix(target_val, quantile)
+            else:
+                similarity_set_val = None
             self.logger.debug("Done")
 
         # now setup the default neural network or not
@@ -328,7 +409,7 @@ class StatisticsLearningNN(StatisticsLearning, GraphTools):
         elif isinstance(embedding_net, list) or embedding_net is None:
             # therefore we need to generate the neural network given the list. The following function returns a class
             # of NN with given input size, output size and hidden sizes; then, need () to instantiate the network
-            self.embedding_net = createDefaultNN(input_size=simulations_reshaped.shape[1], output_size=target.shape[1],
+            self.embedding_net = createDefaultNN(input_size=simulations.shape[1], output_size=target.shape[1],
                                                  hidden_sizes=embedding_net)()
             self.logger.debug('We generate a default neural network')
 
@@ -338,12 +419,13 @@ class StatisticsLearningNN(StatisticsLearning, GraphTools):
         self.logger.debug('We now run the training routine')
 
         if distance_learning:
-            self.embedding_net = training_routine(simulations_reshaped, similarity_set,
-                                                  embedding_net=self.embedding_net, cuda=cuda,
-                                                  **training_routine_kwargs)
+            self.embedding_net = training_routine(simulations, similarity_set, embedding_net=self.embedding_net,
+                                                  cuda=cuda, samples_val=simulations_val,
+                                                  similarity_set_val=similarity_set_val, **training_routine_kwargs)
         else:
-            self.embedding_net = training_routine(simulations_reshaped, target, embedding_net=self.embedding_net,
-                                                  cuda=cuda, **training_routine_kwargs)
+            self.embedding_net = training_routine(simulations, target, embedding_net=self.embedding_net,
+                                                  cuda=cuda, samples_val=simulations_val, target_val=target_val,
+                                                  **training_routine_kwargs)
 
         self.logger.info("Finished learning the transformation.")
 
@@ -371,10 +453,11 @@ class SemiautomaticNN(StatisticsLearningNN):
      computation via deep neural network. Statistica Sinica, pp.1595-1618.
     """
 
-    def __init__(self, model, statistics_calc, backend, embedding_net=None, n_samples=1000, n_samples_per_param=1,
-                 parameters=None, simulations=None, seed=None, cuda=None, batch_size=16, n_epochs=200,
-                 load_all_data_GPU=False, lr=1e-3, optimizer=None, scheduler=None, start_epoch=0, verbose=False,
-                 optimizer_kwargs={}, scheduler_kwargs={}, loader_kwargs={}):
+    def __init__(self, model, statistics_calc, backend, embedding_net=None, n_samples=1000, n_samples_val=0,
+                 n_samples_per_param=1, parameters=None, simulations=None, parameters_val=None, simulations_val=None,
+                 early_stopping=False, epochs_early_stopping_interval=1, start_epoch_early_stopping=10,
+                 seed=None, cuda=None, batch_size=16, n_epochs=200, load_all_data_GPU=False, lr=1e-3, optimizer=None,
+                 scheduler=None, start_epoch_training=0, optimizer_kwargs={}, scheduler_kwargs={}, loader_kwargs={}):
         """
         Parameters
         ----------
@@ -395,17 +478,43 @@ class SemiautomaticNN(StatisticsLearningNN):
             The number of (parameter, simulated data) tuple to be generated to learn the summary statistics in pilot
             step. The default value is 1000.
             This is ignored if `simulations` and `parameters` are provided.
+        n_samples_val: int, optional
+            The number of (parameter, simulated data) tuple to be generated to be used as a validation set in the pilot
+            step. The default value is 0, which means no validation set is used.
+            This is ignored if `simulations_val` and `parameters_val` are provided.
         n_samples_per_param: int, optional
             Number of data points in each simulated data set. This is ignored if `simulations` and `parameters` are
             provided. Default to 1.
         parameters: array, optional
             A numpy array with shape (n_samples, n_parameters) that is used, together with `simulations` to fit the
             summary selection learning algorithm. It has to be provided together with `simulations`, in which case no
-            other simulations are performed. Default value is None.
+            other simulations are performed to generate the training data. Default value is None.
         simulations: array, optional
             A numpy array with shape (n_samples, output_size) that is used, together with `parameters` to fit the
             summary selection learning algorithm. It has to be provided together with `parameters`, in which case no
-            other simulations are performed. Default value is None.
+            other simulations are performed to generate the training data. Default value is None.
+        parameters_val: array, optional
+            A numpy array with shape (n_samples_val, n_parameters) that is used, together with `simulations_val` as a 
+            validation set in the summary selection learning algorithm. It has to be provided together with 
+            `simulations_val`, in which case no other simulations are performed to generate the validation set. Default 
+            value is None.
+        simulations_val: array, optional
+            A numpy array with shape (n_samples_val, output_size) that is used, together with `parameters_val` as a 
+            validation set in the summary selection learning algorithm. It has to be provided together with 
+            `parameters_val`, in which case no other simulations are performed to generate the validation set. Default
+            value is None.
+        early_stopping: boolean, optional
+            If True, the validation set (which needs to be either provided through the arguments `parameters_val` and
+            `simulations_val` or generated by setting `n_samples_val` to a value larger than 0) is used to early stop
+            the training of the neural network as soon as the loss on the validation set starts to increase. Default
+            value is False.
+        epochs_early_stopping_interval: integer, optional
+            The frequency at which the validation error is compared in order to decide whether to early stop the
+            training or not. Namely, if `epochs_early_stopping_interval=10`, early stopping can happen only at epochs multiple of
+            10. Defaul value is 1.
+        start_epoch_early_stopping: integer, optional
+            The epoch after which early stopping can happen; in fact, as soon as training starts, there may be a 
+            transient period in which the loss increases. Default value is 10.
         seed: integer, optional
             Optional initial seed for the random number generator. The default value is generated randomly.
         cuda: boolean, optional
@@ -427,10 +536,10 @@ class SemiautomaticNN(StatisticsLearningNN):
         scheduler: torch _LRScheduler class, optional
             A torch _LRScheduler class, used to modify the learning rate across epochs. By default, no scheduler is
             used. Additional parameters may be passed through the `scheduler_kwargs` parameter.
-        start_epoch: integer, optional
-            If a scheduler is provided, for the first `start_epoch` epochs the scheduler is applied to modify the
-            learning rate without training the network. From then on, the training proceeds normally, applying both the
-            scheduler and the optimizer at each epoch. Default to 0.
+        start_epoch_training: integer, optional
+            If a scheduler is provided, for the first `start_epoch_training` epochs the scheduler is applied to modify
+            the learning rate without training the network. From then on, the training proceeds normally, applying both
+            the scheduler and the optimizer at each epoch. Default to 0.
         verbose: boolean, optional
             if True, prints more information from the training routine. Default to False.
         optimizer_kwargs: Python dictionary, optional
@@ -443,11 +552,17 @@ class SemiautomaticNN(StatisticsLearningNN):
         """
         super(SemiautomaticNN, self).__init__(model, statistics_calc, backend, FP_nn_training, distance_learning=False,
                                               embedding_net=embedding_net, n_samples=n_samples,
-                                              n_samples_per_param=n_samples_per_param, parameters=parameters,
-                                              simulations=simulations, seed=seed, cuda=cuda, batch_size=batch_size,
+                                              n_samples_val=n_samples_val, n_samples_per_param=n_samples_per_param,
+                                              parameters=parameters, simulations=simulations,
+                                              parameters_val=parameters_val, simulations_val=simulations_val,
+                                              early_stopping=early_stopping,
+                                              epochs_early_stopping_interval=epochs_early_stopping_interval,
+                                              start_epoch_early_stopping=start_epoch_early_stopping,
+                                              seed=seed, cuda=cuda, batch_size=batch_size,
                                               n_epochs=n_epochs, load_all_data_GPU=load_all_data_GPU, lr=lr,
-                                              optimizer=optimizer, scheduler=scheduler, start_epoch=start_epoch,
-                                              verbose=verbose, optimizer_kwargs=optimizer_kwargs,
+                                              optimizer=optimizer, scheduler=scheduler,
+                                              start_epoch_training=start_epoch_training,
+                                              optimizer_kwargs=optimizer_kwargs,
                                               scheduler_kwargs=scheduler_kwargs, loader_kwargs=loader_kwargs)
 
 
@@ -464,10 +579,12 @@ class TripletDistanceLearning(StatisticsLearningNN):
      Bayesian Computation To Model a Volcanic Eruption. arXiv preprint arXiv:1909.13118.
     """
 
-    def __init__(self, model, statistics_calc, backend, embedding_net=None, n_samples=1000, n_samples_per_param=1,
-                 parameters=None, simulations=None, seed=None, cuda=None, quantile=0.1, batch_size=16, n_epochs=200,
-                 load_all_data_GPU=False, margin=1., lr=None, optimizer=None, scheduler=None, start_epoch=0,
-                 verbose=False, optimizer_kwargs={}, scheduler_kwargs={}, loader_kwargs={}):
+    def __init__(self, model, statistics_calc, backend, embedding_net=None, n_samples=1000, n_samples_val=0,
+                 n_samples_per_param=1, parameters=None, simulations=None, parameters_val=None, simulations_val=None,
+                 early_stopping=False, epochs_early_stopping_interval=1, start_epoch_early_stopping=10, seed=None,
+                 cuda=None,
+                 quantile=0.1, batch_size=16, n_epochs=200, load_all_data_GPU=False, margin=1., lr=None, optimizer=None,
+                 scheduler=None, start_epoch_training=0, optimizer_kwargs={}, scheduler_kwargs={}, loader_kwargs={}):
         """
         Parameters
         ----------
@@ -488,17 +605,43 @@ class TripletDistanceLearning(StatisticsLearningNN):
             The number of (parameter, simulated data) tuple to be generated to learn the summary statistics in pilot
             step. The default value is 1000.
             This is ignored if `simulations` and `parameters` are provided.
+        n_samples_val: int, optional
+            The number of (parameter, simulated data) tuple to be generated to be used as a validation set in the pilot
+            step. The default value is 0, which means no validation set is used.
+            This is ignored if `simulations_val` and `parameters_val` are provided.
         n_samples_per_param: int, optional
             Number of data points in each simulated data set. This is ignored if `simulations` and `parameters` are
             provided. Default to 1.
         parameters: array, optional
             A numpy array with shape (n_samples, n_parameters) that is used, together with `simulations` to fit the
             summary selection learning algorithm. It has to be provided together with `simulations`, in which case no
-            other simulations are performed. Default value is None.
+            other simulations are performed to generate the training data. Default value is None.
         simulations: array, optional
             A numpy array with shape (n_samples, output_size) that is used, together with `parameters` to fit the
             summary selection learning algorithm. It has to be provided together with `parameters`, in which case no
-            other simulations are performed. Default value is None.
+            other simulations are performed to generate the training data. Default value is None.
+        parameters_val: array, optional
+            A numpy array with shape (n_samples_val, n_parameters) that is used, together with `simulations_val` as a 
+            validation set in the summary selection learning algorithm. It has to be provided together with 
+            `simulations_val`, in which case no other simulations are performed to generate the validation set. Default 
+            value is None.
+        simulations_val: array, optional
+            A numpy array with shape (n_samples_val, output_size) that is used, together with `parameters_val` as a 
+            validation set in the summary selection learning algorithm. It has to be provided together with 
+            `parameters_val`, in which case no other simulations are performed to generate the validation set. Default
+            value is None.
+        early_stopping: boolean, optional
+            If True, the validation set (which needs to be either provided through the arguments `parameters_val` and
+            `simulations_val` or generated by setting `n_samples_val` to a value larger than 0) is used to early stop
+            the training of the neural network as soon as the loss on the validation set starts to increase. Default
+            value is False.
+        epochs_early_stopping_interval: integer, optional
+            The frequency at which the validation error is compared in order to decide whether to early stop the
+            training or not. Namely, if `epochs_early_stopping_interval=10`, early stopping can happen only at epochs
+            multiple of 10. Defaul value is 1.
+        start_epoch_early_stopping: integer, optional
+            The epoch after which early stopping can happen; in fact, as soon as training starts, there may be a 
+            transient period in which the loss increases. Default value is 10.
         seed: integer, optional
             Optional initial seed for the random number generator. The default value is generated randomly.
         cuda: boolean, optional
@@ -525,10 +668,10 @@ class TripletDistanceLearning(StatisticsLearningNN):
         scheduler: torch _LRScheduler class, optional
             A torch _LRScheduler class, used to modify the learning rate across epochs. By default, no scheduler is
             used. Additional parameters may be passed through the `scheduler_kwargs` parameter.
-        start_epoch: integer, optional
-            If a scheduler is provided, for the first `start_epoch` epochs the scheduler is applied to modify the
-            learning rate without training the network. From then on, the training proceeds normally, applying both the
-            scheduler and the optimizer at each epoch. Default to 0.
+        start_epoch_training: integer, optional
+            If a scheduler is provided, for the first `start_epoch_training` epochs the scheduler is applied to modify
+            the learning rate without training the network. From then on, the training proceeds normally, applying both
+            the scheduler and the optimizer at each epoch. Default to 0.
         verbose: boolean, optional
             if True, prints more information from the training routine. Default to False.
         optimizer_kwargs: Python dictionary, optional
@@ -542,12 +685,17 @@ class TripletDistanceLearning(StatisticsLearningNN):
 
         super(TripletDistanceLearning, self).__init__(model, statistics_calc, backend, triplet_training,
                                                       distance_learning=True, embedding_net=embedding_net,
-                                                      n_samples=n_samples, n_samples_per_param=n_samples_per_param,
-                                                      parameters=parameters, simulations=simulations, seed=seed,
-                                                      cuda=cuda, quantile=quantile, batch_size=batch_size,
+                                                      n_samples=n_samples, n_samples_val=n_samples_val,
+                                                      n_samples_per_param=n_samples_per_param,
+                                                      parameters=parameters, simulations=simulations,
+                                                      parameters_val=parameters_val, simulations_val=simulations_val,
+                                                      early_stopping=early_stopping,
+                                                      epochs_early_stopping_interval=epochs_early_stopping_interval,
+                                                      start_epoch_early_stopping=start_epoch_early_stopping,
+                                                      seed=seed, cuda=cuda, quantile=quantile, batch_size=batch_size,
                                                       n_epochs=n_epochs, load_all_data_GPU=load_all_data_GPU,
                                                       margin=margin, lr=lr, optimizer=optimizer, scheduler=scheduler,
-                                                      start_epoch=start_epoch, verbose=verbose,
+                                                      start_epoch_training=start_epoch_training,
                                                       optimizer_kwargs=optimizer_kwargs,
                                                       scheduler_kwargs=scheduler_kwargs, loader_kwargs=loader_kwargs)
 
@@ -566,10 +714,12 @@ class ContrastiveDistanceLearning(StatisticsLearningNN):
      Bayesian Computation To Model a Volcanic Eruption. arXiv preprint arXiv:1909.13118.
     """
 
-    def __init__(self, model, statistics_calc, backend, embedding_net=None, n_samples=1000, n_samples_per_param=1,
-                 parameters=None, simulations=None, seed=None, cuda=None, quantile=0.1, batch_size=16, n_epochs=200,
-                 positive_weight=None, load_all_data_GPU=False, margin=1., lr=None, optimizer=None, scheduler=None,
-                 start_epoch=0, verbose=False, optimizer_kwargs={}, scheduler_kwargs={}, loader_kwargs={}):
+    def __init__(self, model, statistics_calc, backend, embedding_net=None, n_samples=1000, n_samples_val=0,
+                 n_samples_per_param=1, parameters=None, simulations=None, parameters_val=None, simulations_val=None,
+                 early_stopping=False, epochs_early_stopping_interval=1, start_epoch_early_stopping=10, seed=None,
+                 cuda=None, quantile=0.1, batch_size=16, n_epochs=200, positive_weight=None, load_all_data_GPU=False,
+                 margin=1., lr=None, optimizer=None, scheduler=None,
+                 start_epoch_training=0, optimizer_kwargs={}, scheduler_kwargs={}, loader_kwargs={}):
         """
         Parameters
         ----------
@@ -631,10 +781,10 @@ class ContrastiveDistanceLearning(StatisticsLearningNN):
         scheduler: torch _LRScheduler class, optional
             A torch _LRScheduler class, used to modify the learning rate across epochs. By default, no scheduler is
             used. Additional parameters may be passed through the `scheduler_kwargs` parameter.
-        start_epoch: integer, optional
-            If a scheduler is provided, for the first `start_epoch` epochs the scheduler is applied to modify the
-            learning rate without training the network. From then on, the training proceeds normally, applying both the
-            scheduler and the optimizer at each epoch. Default to 0.
+        start_epoch_training: integer, optional
+            If a scheduler is provided, for the first `start_epoch_training` epochs the scheduler is applied to modify
+            the learning rate without training the network. From then on, the training proceeds normally, applying both
+            the scheduler and the optimizer at each epoch. Default to 0.
         verbose: boolean, optional
             if True, prints more information from the training routine. Default to False.
         optimizer_kwargs: Python dictionary, optional
@@ -648,13 +798,20 @@ class ContrastiveDistanceLearning(StatisticsLearningNN):
 
         super(ContrastiveDistanceLearning, self).__init__(model, statistics_calc, backend, contrastive_training,
                                                           distance_learning=True, embedding_net=embedding_net,
-                                                          n_samples=n_samples, n_samples_per_param=n_samples_per_param,
-                                                          parameters=parameters, simulations=simulations, seed=seed,
-                                                          cuda=cuda, quantile=quantile, batch_size=batch_size,
-                                                          n_epochs=n_epochs, positive_weight=positive_weight,
+                                                          n_samples=n_samples, n_samples_val=n_samples_val,
+                                                          n_samples_per_param=n_samples_per_param,
+                                                          parameters=parameters, simulations=simulations,
+                                                          parameters_val=parameters_val,
+                                                          simulations_val=simulations_val,
+                                                          early_stopping=early_stopping,
+                                                          epochs_early_stopping_interval=epochs_early_stopping_interval,
+                                                          start_epoch_early_stopping=start_epoch_early_stopping,
+                                                          seed=seed, cuda=cuda, quantile=quantile,
+                                                          batch_size=batch_size, n_epochs=n_epochs,
+                                                          positive_weight=positive_weight,
                                                           load_all_data_GPU=load_all_data_GPU, margin=margin, lr=lr,
                                                           optimizer=optimizer, scheduler=scheduler,
-                                                          start_epoch=start_epoch, verbose=verbose,
+                                                          start_epoch_training=start_epoch_training,
                                                           optimizer_kwargs=optimizer_kwargs,
                                                           scheduler_kwargs=scheduler_kwargs,
                                                           loader_kwargs=loader_kwargs)

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -336,7 +336,7 @@ The source code can be found in `examples/approx_lhd/pmc_hierarchical_models.py`
 Statistics Learning
 ~~~~~~~~~~~~~~~~~~~
 
-We have noticed in the `Parameters as Random Variables`_ Section, the discrepancy measure between two datasets is
+As we have discussed in the `Parameters as Random Variables`_ Section, the discrepancy measure between two datasets is
 defined by a distance function between extracted summary statistics from the datasets. Hence, the ABC algorithms are
 subjective to the summary statistics choice. This subjectivity can be avoided by a data-driven summary statistics choice
 from the available summary statistics of the dataset. In ABCpy we provide several statistics learning procedures,
@@ -360,6 +360,12 @@ called, ABCpy checks if Pytorch is present and, if not, asks the user to install
 provide a specific form of neural network, the implementation of the neural network based ones do not require any
 explicit neural network coding, handling all the necessary definitions and training internally.
 
+It is also possible to provide a validation set to the neural network based training routines in order to monitor the
+loss on fresh samples. This can be done for instance by set the parameter `n_samples_val` to a value larger than 0.
+Moreover, it is possible to use the validation set for early stopping, ie stopping the training as soon as the loss on
+the validation set starts increasing. You can do this by setting `early_stopping=True`. Please refer to the API documentation
+(for instance :py:class:`abcpy.statisticslearning.SemiautomaticNN`) for further details.
+
 We note finally that the statistics learning techniques can be applied after compute a first set of statistics; therefore,
 the learned transformation will be a transformation applied to the original set of statistics.
 For instance, consider our initial example from `Parameters as Random Variables`_ where we model the height of humans.
@@ -382,7 +388,7 @@ We remark that the minimal amount of coding needed for using the neural network 
 
 .. literalinclude:: ../../examples/statisticslearning/pmcabc_gaussian_statistics_learning.py
     :language: python
-    :lines: 34-40
+    :lines: 34-42
     :dedent: 4
 
 And similarly for the other two approaches.

--- a/doc/source/postanalysis.rst
+++ b/doc/source/postanalysis.rst
@@ -63,6 +63,16 @@ Finally, you can plot the inferred posterior mean of the parameters in the follo
     :lines: 65
     :dedent: 4
 
+The above line plots the posterior distribution for all the parameters; if you instead want to plot it for some
+parameters only, you can use the `parameters_to_show` argument; in addition, the `ranges_parameters` argument can be
+used to provide a dictionary specifying the limits for the axis in the plots:
+
+.. code-block:: python
+
+    journal.plot_posterior_distr(parameters_to_show='parameter_1',
+                                 ranges_parameters={'parameter_1': [0,2]})
+
+
 And certainly, a journal can easily be saved to and loaded from disk:
 
 .. literalinclude:: ../../examples/backends/dummy/pmcabc_gaussian.py

--- a/examples/statisticslearning/pmcabc_gaussian_statistics_learning.py
+++ b/examples/statisticslearning/pmcabc_gaussian_statistics_learning.py
@@ -25,16 +25,18 @@ def infer_parameters():
     # Learn the optimal summary statistics using Semiautomatic summary selection
     from abcpy.statisticslearning import Semiautomatic
     statistics_learning = Semiautomatic([height], statistics_calculator, backend,
-                                      n_samples=1000,n_samples_per_param=1, seed=1)
+                                        n_samples=1000, n_samples_per_param=1, seed=1)
 
     # Redefine the statistics function
     new_statistics_calculator = statistics_learning.get_statistics()
 
 
-    # Learn the optimal summary statistics using SemiautomaticNN summary selection
+    # Learn the optimal summary statistics using SemiautomaticNN summary selection;
+    # we use 200 samples as a validation set for early stopping:
     from abcpy.statisticslearning import SemiautomaticNN
     statistics_learning = SemiautomaticNN([height], statistics_calculator, backend,
-                                        n_samples=1000,n_samples_per_param=1, seed=1)
+                                          n_samples=1000, n_samples_val=200,
+                                          n_samples_per_param=1, seed=1, early_stopping=True)
 
     # Redefine the statistics function
     new_statistics_calculator = statistics_learning.get_statistics()

--- a/tests/statisticslearning_tests.py
+++ b/tests/statisticslearning_tests.py
@@ -63,7 +63,11 @@ class SemiautomaticNNTests(unittest.TestCase):
         if has_torch:
             # Initialize statistics learning
             self.statisticslearning = SemiautomaticNN([self.Y], self.statistics_cal, self.backend, n_samples=100,
-                                                      n_samples_per_param=1, seed=1, n_epochs=10)
+                                                      n_samples_per_param=1, seed=1, n_epochs=10, scale_samples=False)
+            # with sample scaler:
+            self.statisticslearning_with_scaler = SemiautomaticNN([self.Y], self.statistics_cal, self.backend,
+                                                                  n_samples=100, n_samples_per_param=1, seed=1,
+                                                                  n_epochs=10, scale_samples=True)
 
     def test_initialization(self):
         if not has_torch:
@@ -73,6 +77,7 @@ class SemiautomaticNNTests(unittest.TestCase):
         if has_torch:
             # Transform statistics extraction
             self.new_statistics_calculator = self.statisticslearning.get_statistics()
+            self.new_statistics_calculator_with_scaler = self.statisticslearning_with_scaler.get_statistics()
             # Simulate observed data
             Obs = Normal([2, 4])
             y_obs = Obs.forward_simulate(Obs.get_input_values(), 1)[0].tolist()
@@ -81,6 +86,11 @@ class SemiautomaticNNTests(unittest.TestCase):
             self.assertEqual(np.shape(extracted_statistics), (1, 2))
 
             self.assertRaises(RuntimeError, self.new_statistics_calculator.statistics, [np.array([1, 2])])
+
+            extracted_statistics = self.new_statistics_calculator_with_scaler.statistics(y_obs)
+            self.assertEqual(np.shape(extracted_statistics), (1, 2))
+
+            self.assertRaises(ValueError, self.new_statistics_calculator_with_scaler.statistics, [np.array([1, 2])])
 
 
 class ContrastiveDistanceLearningTests(unittest.TestCase):
@@ -100,7 +110,12 @@ class ContrastiveDistanceLearningTests(unittest.TestCase):
             # Initialize statistics learning
             self.statisticslearning = ContrastiveDistanceLearning([self.Y], self.statistics_cal, self.backend,
                                                                   n_samples=100, n_samples_per_param=1, seed=1,
-                                                                  n_epochs=10)
+                                                                  n_epochs=10, scale_samples=False)
+            # with sample scaler:
+            self.statisticslearning_with_scaler = ContrastiveDistanceLearning([self.Y], self.statistics_cal,
+                                                                              self.backend, n_samples=100,
+                                                                              n_samples_per_param=1, seed=1,
+                                                                              n_epochs=10, scale_samples=True)
 
     def test_initialization(self):
         if not has_torch:
@@ -111,6 +126,7 @@ class ContrastiveDistanceLearningTests(unittest.TestCase):
         if has_torch:
             # Transform statistics extraction
             self.new_statistics_calculator = self.statisticslearning.get_statistics()
+            self.new_statistics_calculator_with_scaler = self.statisticslearning_with_scaler.get_statistics()
             # Simulate observed data
             Obs = Normal([2, 4])
             y_obs = Obs.forward_simulate(Obs.get_input_values(), 1)[0].tolist()
@@ -119,6 +135,11 @@ class ContrastiveDistanceLearningTests(unittest.TestCase):
             self.assertEqual(np.shape(extracted_statistics), (1, 2))
 
             self.assertRaises(RuntimeError, self.new_statistics_calculator.statistics, [np.array([1, 2])])
+
+            extracted_statistics = self.new_statistics_calculator_with_scaler.statistics(y_obs)
+            self.assertEqual(np.shape(extracted_statistics), (1, 2))
+
+            self.assertRaises(ValueError, self.new_statistics_calculator_with_scaler.statistics, [np.array([1, 2])])
 
 
 class TripletDistanceLearningTests(unittest.TestCase):
@@ -137,6 +158,11 @@ class TripletDistanceLearningTests(unittest.TestCase):
         if has_torch:
             # Initialize statistics learning
             self.statisticslearning = TripletDistanceLearning([self.Y], self.statistics_cal, self.backend,
+                                                              scale_samples=False,
+                                                              n_samples=100, n_samples_per_param=1, seed=1, n_epochs=10)
+            # with sample scaler:
+            self.statisticslearning_with_scaler = TripletDistanceLearning([self.Y], self.statistics_cal, self.backend,
+                                                              scale_samples=True,
                                                               n_samples=100, n_samples_per_param=1, seed=1, n_epochs=10)
 
     def test_initialization(self):
@@ -147,6 +173,7 @@ class TripletDistanceLearningTests(unittest.TestCase):
         if has_torch:
             # Transform statistics extraction
             self.new_statistics_calculator = self.statisticslearning.get_statistics()
+            self.new_statistics_calculator_with_scaler = self.statisticslearning_with_scaler.get_statistics()
             # Simulate observed data
             Obs = Normal([2, 4])
             y_obs = Obs.forward_simulate(Obs.get_input_values(), 1)[0].tolist()
@@ -155,6 +182,11 @@ class TripletDistanceLearningTests(unittest.TestCase):
             self.assertEqual(np.shape(extracted_statistics), (1, 2))
 
             self.assertRaises(RuntimeError, self.new_statistics_calculator.statistics, [np.array([1, 2])])
+
+            extracted_statistics = self.new_statistics_calculator_with_scaler.statistics(y_obs)
+            self.assertEqual(np.shape(extracted_statistics), (1, 2))
+
+            self.assertRaises(ValueError, self.new_statistics_calculator_with_scaler.statistics, [np.array([1, 2])])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We added some improvements to the statistics learning routines with neural networks , specifically: 

- Added the possibility to provide a validation set for monitoring the loss during training, and which can be in addition used for early stopping. 
- Added a scaler (from sklearn) that transforms the data range before applying the neural network; this is active by default (as neural network training improves with input data in the [0,1] range), but can be deactivated. After training and during ABC inference, the statistic computation will automatically apply the scaler before feeding the simulated data through the network. 
- Fixed a small bug in the code handling choice of CPU/GPU during neural network training.
- Some minor updates in the docs.