### PR TITLE
Add coverage badge and tracking

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+branch = True
+source = abcpy
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+    if False:
+ignore_errors = True
+omit =
+    tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 - pip install -r requirements/optional-requirements.txt
 - pip install -r requirements/coverage.txt
 script:
-- make test
+# - make test
 - make coveragetest
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,12 @@ install:
 - pip install -r requirements/backend-mpi.txt
 - pip install -r requirements/backend-spark.txt
 - pip install -r requirements/optional-requirements.txt
+- pip install -r requirements/coverage.txt
 script:
 - make test
+- make coveragetest
+after_success:
+- bash <(curl -s https://codecov.io/bash)
 before_deploy:
 - make clean
 - mkdir dist

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ABCpy [![Documentation Status](https://readthedocs.org/projects/abcpy/badge/?version=latest)](http://abcpy.readthedocs.io/en/latest/?badge=latest) [![Build Status](https://travis-ci.org/eth-cscs/abcpy.svg?branch=master)](https://travis-ci.org/eth-cscs/abcpy)
+[![codecov](https://codecov.io/gh/LoryPack/abcpy/branch/coverage/graph/badge.svg)](https://codecov.io/gh/LoryPack/abcpy)
 
 ABCpy is a scientific library written in Python for Bayesian uncertainty quantification in
 absence of likelihood function, which parallelizes existing approximate Bayesian computation (ABC) 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ABCpy [![Documentation Status](https://readthedocs.org/projects/abcpy/badge/?version=latest)](http://abcpy.readthedocs.io/en/latest/?badge=latest) [![Build Status](https://travis-ci.org/eth-cscs/abcpy.svg?branch=master)](https://travis-ci.org/eth-cscs/abcpy) [![codecov](https://codecov.io/gh/LoryPack/abcpy/branch/coverage/graph/badge.svg)](https://codecov.io/gh/LoryPack/abcpy)
+# ABCpy [![Documentation Status](https://readthedocs.org/projects/abcpy/badge/?version=latest)](http://abcpy.readthedocs.io/en/latest/?badge=latest) [![Build Status](https://travis-ci.org/eth-cscs/abcpy.svg?branch=master)](https://travis-ci.org/eth-cscs/abcpy) [![codecov](https://codecov.io/gh/eth-cscs/abcpy/branch/master/graph/badge.svg)](https://codecov.io/gh/eth-cscs/abcpy)
 
 ABCpy is a scientific library written in Python for Bayesian uncertainty quantification in
 absence of likelihood function, which parallelizes existing approximate Bayesian computation (ABC) 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# ABCpy [![Documentation Status](https://readthedocs.org/projects/abcpy/badge/?version=latest)](http://abcpy.readthedocs.io/en/latest/?badge=latest) [![Build Status](https://travis-ci.org/eth-cscs/abcpy.svg?branch=master)](https://travis-ci.org/eth-cscs/abcpy)
-[![codecov](https://codecov.io/gh/LoryPack/abcpy/branch/coverage/graph/badge.svg)](https://codecov.io/gh/LoryPack/abcpy)
+# ABCpy [![Documentation Status](https://readthedocs.org/projects/abcpy/badge/?version=latest)](http://abcpy.readthedocs.io/en/latest/?badge=latest) [![Build Status](https://travis-ci.org/eth-cscs/abcpy.svg?branch=master)](https://travis-ci.org/eth-cscs/abcpy) [![codecov](https://codecov.io/gh/LoryPack/abcpy/branch/coverage/graph/badge.svg)](https://codecov.io/gh/LoryPack/abcpy)
 
 ABCpy is a scientific library written in Python for Bayesian uncertainty quantification in
 absence of likelihood function, which parallelizes existing approximate Bayesian computation (ABC) 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 scipy
-sklearn==0.22.0
+scikit-learn==0.22.0
 glmnet==2.0.0
 sphinx
 sphinx_rtd_theme 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 scipy
-sklearn
+sklearn==0.22
 glmnet==2.0.0
 sphinx
 sphinx_rtd_theme 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 scipy
-sklearn==0.22
+sklearn==0.22.0
 glmnet==2.0.0
 sphinx
 sphinx_rtd_theme 

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -1,0 +1,1 @@
+codecov


### PR DESCRIPTION
This pull request introduces coverage badge in README and computation of coverage in continuouos integration in travis. 

I am pushing this to master branch directly as this does not introduce any change to the source code. 