### PR TITLE
fix possible bug with PMCABC loading from a journal

### DIFF
--- a/abcpy/inferences.py
+++ b/abcpy/inferences.py
@@ -378,6 +378,9 @@ class PMCABC(BaseDiscrepancy, InferenceMethod):
         journal_file: str, optional
             Filename of a journal file to read an already saved journal file, from which the first iteration will start.
             The default value is None.
+        journal_class: instance of Journal, optional
+            An instance of Journal from which the first iteration will start.
+            The default value is None. 
 
         Returns
         -------

--- a/abcpy/inferences.py
+++ b/abcpy/inferences.py
@@ -434,7 +434,7 @@ class PMCABC(BaseDiscrepancy, InferenceMethod):
                 self.logger.info("Calculateing covariance matrix")
                 new_cov_mats = self.kernel.calculate_cov(self.accepted_parameters_manager)
                 # Since each entry of new_cov_mats is a numpy array, we can multiply like this
-                # accepted_cov_mats = [covFactor * new_cov_mat for new_cov_mat in new_cov_mats]
+                accepted_cov_mats = [covFactor * new_cov_mat for new_cov_mat in new_cov_mats]
                 accepted_cov_mats = self._compute_accepted_cov_mats(covFactor, accepted_cov_mats)
 
             seed_arr = self.rng.randint(0, np.iinfo(np.uint32).max, size=n_samples, dtype=np.uint32)

--- a/abcpy/inferences.py
+++ b/abcpy/inferences.py
@@ -350,7 +350,7 @@ class PMCABC(BaseDiscrepancy, InferenceMethod):
         self.simulation_counter = 0
 
     def sample(self, observations, steps, epsilon_init, n_samples=10000, n_samples_per_param=1, epsilon_percentile=10,
-               covFactor=2, full_output=0, journal_file=None):
+               covFactor=2, full_output=0, journal_file=None, journal_class=None):
         """Samples from the posterior distribution of the model parameter given the observed
         data observations.
 
@@ -388,7 +388,7 @@ class PMCABC(BaseDiscrepancy, InferenceMethod):
         self.n_samples = n_samples
         self.n_samples_per_param = n_samples_per_param
 
-        if journal_file is None:
+        if journal_file is None and journal_class is None:
             journal = Journal(full_output)
             journal.configuration["type_model"] = [type(model).__name__ for model in self.model]
             journal.configuration["type_dist_func"] = type(self.distance).__name__
@@ -397,7 +397,13 @@ class PMCABC(BaseDiscrepancy, InferenceMethod):
             journal.configuration["steps"] = steps
             journal.configuration["epsilon_percentile"] = epsilon_percentile
         else:
-            journal = Journal.fromFile(journal_file)
+            if journal_file is not None and journal_class is not None:
+                raise Exception('When initializing from journal must specify either the path to the journal file with '
+                                'journal_file OR the journal instance itself with journal_class, not both.')
+            if journal_file is not None:
+                journal = Journal.fromFile(journal_file)
+            elif journal_class is not None:
+                journal = journal_class
 
         accepted_parameters = None
         accepted_weights = None

--- a/tests/inferences_tests.py
+++ b/tests/inferences_tests.py
@@ -219,7 +219,7 @@ class PMCABCTests(unittest.TestCase):
         journal_init = sampler.sample([self.observation], T, eps_arr, n_sample, n_simulate, eps_percentile)
 
         # Test from journal class
-        T, n_sample, n_simulate, eps_arr, eps_percentile = 1, 11, 1, [5], 10
+        T, n_sample, n_simulate, eps_arr, eps_percentile = 1, 10, 1, [5], 10
         journal = sampler.sample([self.observation], T, eps_arr, n_sample, n_simulate, eps_percentile, journal_class=journal_init)
 
         mu_post_sample, sigma_post_sample, post_weights = np.array(journal.get_parameters()['mu']), np.array(
@@ -233,9 +233,9 @@ class PMCABCTests(unittest.TestCase):
                                                                     (len(sigma_post_sample),
                                                                      sigma_post_sample[0].shape[1]), post_weights.shape
 
-        self.assertEqual(mu_sample_shape, (11, 1))
-        self.assertEqual(sigma_sample_shape, (11, 1))
-        self.assertEqual(weights_sample_shape, (11, 1))
+        self.assertEqual(mu_sample_shape, (10, 1))
+        self.assertEqual(sigma_sample_shape, (10, 1))
+        self.assertEqual(weights_sample_shape, (10, 1))
         self.assertLess(mu_post_mean - 0.03713, 10e-2)
         self.assertLess(sigma_post_mean - 7.727, 10e-2)
 


### PR DESCRIPTION
Hi, I seem to have encountered a bug when launching a new PMCABC routine a pre-computed journal class. The accepted_cov_mats parameter is set to None in the "sample" routine, and then passed to self._compute_accepted_cov_mats, which subsequently crashes because it expects a list or an array. I fixed this by uncommenting the line directly above self._compute_accepted_cov_mats, which seems to compute accepted_cov_mats from the supplied instance of Journal. This seems to have fixed the problem. 

I have added a test function for the PMCABC class to test the functionality of restarting an inference from a precomputed journal. To avoid writing and reading a pickled journal class inside the test function, I have added the option to start a new inference directly from an instance of Journal, rather than from a file path. The code should be backwards compatible and not interfere with previous versions 