### PR TITLE
Remove deprecated `sklearn` from `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ numpy
 scipy
 scikit-learn>=0.23.1
 glmnet>=2.2.1
-sklearn
 sphinx
 sphinx_rtd_theme 
 coverage


### PR DESCRIPTION
Hey - this PR removes the `sklearn` entry from the `requirements.txt` files, since installing the `sklearn` package from `PyPI` is now deprecated, see https://github.com/scikit-learn/sklearn-pypi-package.